### PR TITLE
Destroy Item Reset

### DIFF
--- a/src/main/java/io/github/codeutilities/mod/config/config/MiscellaneousGroup.java
+++ b/src/main/java/io/github/codeutilities/mod/config/config/MiscellaneousGroup.java
@@ -17,6 +17,7 @@ public class MiscellaneousGroup extends ConfigGroup {
         // Non sub-grouped
         this.register(new BooleanSetting("itemApi", true));
         this.register(new BooleanSetting("quickVarScope", true));
+        this.register(new BooleanSetting("destroyItemReset", false));
 
         // Discord
         ConfigSubGroup discord = new ConfigSubGroup("discordrpc");

--- a/src/main/java/io/github/codeutilities/mod/mixin/screen/MixinCreativeInventoryScreen.java
+++ b/src/main/java/io/github/codeutilities/mod/mixin/screen/MixinCreativeInventoryScreen.java
@@ -1,0 +1,30 @@
+package io.github.codeutilities.mod.mixin.screen;
+
+import io.github.codeutilities.CodeUtilities;
+import io.github.codeutilities.mod.config.Config;
+import io.github.codeutilities.sys.util.networking.DFInfo;
+import io.github.codeutilities.sys.util.networking.State;
+import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
+import net.minecraft.screen.slot.Slot;
+import net.minecraft.screen.slot.SlotActionType;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(CreativeInventoryScreen.class)
+public class MixinCreativeInventoryScreen {
+    @Shadow @Nullable private Slot deleteItemSlot;
+
+    @Inject(method = "onMouseClick", at = @At("HEAD"), cancellable = true)
+    public void onMouseClick(Slot slot, int slotId, int button, SlotActionType actionType, CallbackInfo ci) {
+        if (Config.getBoolean("destroyItemReset") && DFInfo.isOnDF() && DFInfo.currentState.getMode() == State.CurrentState.Mode.DEV
+                && actionType == SlotActionType.QUICK_MOVE && slot == this.deleteItemSlot) {
+            CodeUtilities.MC.setScreen(null);
+            CodeUtilities.MC.player.sendChatMessage("/rc");
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/assets/codeutilities/lang/en_us.json
+++ b/src/main/resources/assets/codeutilities/lang/en_us.json
@@ -168,6 +168,8 @@
 	"config.codeutilities.option.f3Tps.tooltip": "Shows the client TPS on the Debug Screen (F3).",
     "config.codeutilities.option.quickVarScope": "Quick Variable Scope",
     "config.codeutilities.option.quickVarScope.tooltip": "Typing \"-s\", \"-l\" or \"-g\" after a\nvariable name in chat will change its scope,\nsimilar to the way /var works.",
+    "config.codeutilities.option.destroyItemReset": "Destroy Item Reset",
+    "config.codeutilities.option.destroyItemReset.tooltip": "Resets your inventory to the /rc items after shift clicking the destroy item slot while in dev mode.",
 
     "config.codeutilities.subcategory.misc_audio": "Project: Audio",
     "config.codeutilities.option.audioUrl": "Backend Endpoint",

--- a/src/main/resources/codeutilities.mixins.json
+++ b/src/main/resources/codeutilities.mixins.json
@@ -24,7 +24,8 @@
     "render.MixinSignBlockEntityRender",
     "screen.MixinOptionsScreen",
     "screen.MixinTitleScreen",
-    "screen.MixinChatScreen"
+    "screen.MixinChatScreen",
+    "screen.MixinCreativeInventoryScreen"
   ],
   "client": [],
   "server": [],


### PR DESCRIPTION
Quoting the trello card: Make the creative clear inventory button give the /rc items when in dev mode
https://trello.com/c/S3szGrwi/9-make-the-creative-clear-inventory-button-give-the-rc-items-when-in-dev-mode