### PR TITLE
values crash fix

### DIFF
--- a/src/main/java/io/github/codeutilities/mod/mixin/render/MGenericContainerScreen.java
+++ b/src/main/java/io/github/codeutilities/mod/mixin/render/MGenericContainerScreen.java
@@ -71,6 +71,11 @@ public abstract class MGenericContainerScreen extends HandledScreen<GenericConta
             return;
         }
 
+        // values menu would crash here.
+        if (items.size() != 27) {
+            return;
+        }
+
         for (int i = 0; i < ditem.getTags(); i++) {
             items.set(26 - i, new ItemStack(Items.AIR));
         }


### PR DESCRIPTION
Fixes the value crash bug where opening a chest while holding the values ingot would cause the game to commit die.